### PR TITLE
chore: add Claude Code configuration

### DIFF
--- a/.claude/rules/javascript.md
+++ b/.claude/rules/javascript.md
@@ -1,0 +1,105 @@
+---
+paths:
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.mjs"
+  - "**/*.cjs"
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.mts"
+  - "**/*.cts"
+---
+
+# JavaScript Conventions
+
+Clarity is the highest virtue — if control flow needs a comment, rewrite it. Prefer boring patterns over clever
+tricks. If existing code contradicts a rule below, follow the code and flag the divergence. For TypeScript files these
+rules are the base layer; [typescript.md](typescript.md) stacks on top.
+
+## Declarations & Naming
+
+- `const` by default, `let` only when reassigned, never `var`. One declaration per line; `const` group before `let`.
+  `const` prevents reassignment, not mutation.
+- camelCase for variables/functions, PascalCase for classes, `#private` class fields (not `_` convention),
+  `is`/`has`/`can`/`should` prefixes for booleans, kebab-case file names.
+- SCREAMING_SNAKE_CASE only for true compile-time constants — a variable holding a computed value is camelCase.
+- Descriptive names; short names (`i`, `x`) only in tiny scopes. Accepted abbreviations: `url`, `id`, `err`, `ctx`,
+  `req`, `res` — avoid others. No redundant context (`car.make`, not `car.carMake`). Same word for the same concept
+  across the codebase.
+
+## Equality & Safety
+
+- Always `===`/`!==`; the only valid `==` is `value == null` (catches both `null` and `undefined`).
+- `??` over `||` for defaults — `||` swallows `0`, `""`, `false`.
+- `?.` sparingly: data you expect to exist should throw, not silently yield `undefined`.
+- Falsy values: `false`, `0`, `-0`, `0n`, `""`, `null`, `undefined`, `NaN` — everything else is truthy, including
+  `[]`, `{}`, `"0"`.
+- Ternaries: one-liner or one-branch-per-line only; anything else becomes `if`/`else` or early return. Nested
+  ternaries are banned — no exceptions.
+
+## Syntax
+
+- Template literals only when interpolating; plain quotes otherwise.
+- Spread for copies (`{ ...obj }`, `[...arr]`), never `Object.assign`. Shorthand properties, grouped at the top of
+  the literal. Computed keys `{ [key]: value }`. Logical assignment: `opts.timeout ??= 5000`.
+
+## Functions
+
+- Arrows for callbacks/anonymous functions; function declarations when hoisting or `this` binding is needed.
+  Parentheses around single arrow params. Never arrows as object methods or on prototypes (lexical `this`).
+- Destructured options object for 3+ parameters. Default parameters over `||`/manual checks. Rest params over
+  `arguments`.
+- Early return, guard clauses first, happy path flat. One function, one job — a name containing "and" means split.
+  Keep under ~30 lines; extract helpers.
+- Prefer pure functions; isolate side effects (DOM, network, logging) — don't hide them inside data transformations.
+- Closures retain references, not copies — beware large objects captured unintentionally.
+
+## Async
+
+- `async`/`await` over `.then()` chains. Always `await` promises — a floating promise is a silent failure.
+  Fire-and-forget must attach `.catch(reportError)`.
+- `return await` only inside `try` where you catch the error; otherwise return the promise directly.
+- Parallel independent work: `Promise.all`; all results regardless of failure: `Promise.allSettled`; timeout:
+  `Promise.race`; fallback: `Promise.any`. No sequential awaits in loops — `Promise.all(items.map(...))`, or a
+  concurrency limiter (`p-map`) for large arrays.
+- Throw `Error` objects, never strings. Custom error classes (extend `Error`, set `name`, add context) when callers
+  must distinguish.
+- Never swallow errors — every `catch` handles, rethrows, or reports; `console.log(err)` is not handling. Let errors
+  propagate to a top-level handler; don't wrap every `await` in `try`/`catch`.
+- `new Promise()` only to wrap callback APIs. `AbortController`/`{ signal }` for cancellation. `for await...of` for
+  async iterables.
+
+## Modules
+
+- ES modules only; CommonJS is legacy. Named exports over default (exceptions: framework-required conventions).
+  Never export mutable `let` — export accessor functions.
+- Imports at top, grouped with blank lines: built-in (`node:fs`), external, internal. Merge imports from the same
+  module. Namespace import (`import * as x`) at 5+ items, named below that.
+- Include file extensions in relative import paths (`"./user.js"`); no directory imports resolving to `index.js`.
+- No barrel files in subdirectories — acceptable only as a package entry point enforced via `package.json` `exports`.
+  No wildcard re-exports. No circular dependencies — extract a third module or inject.
+- Dynamic `import()` for code splitting: routes, large conditional deps, feature flags. One concern per module.
+  Side-effect imports are rare and documented.
+
+## Objects, Arrays, Classes
+
+- Literals (`{}`, `[]`), never constructors. Method shorthand. Dot notation for static keys, brackets for dynamic.
+  `Object.hasOwn(obj, key)` over `hasOwnProperty`.
+- Functional methods (`map`/`filter`/`find`/`some`/`every`/`flatMap`/`reduce`) for transforms — always return in the
+  callback; `for...of` for side-effect loops; never `for...in` on arrays.
+- Don't mutate inputs — return new objects/arrays: add `[...arr, item]`, remove `arr.filter`, update `arr.map`.
+  Return objects (not arrays) for multiple values. `Array.from(arrayLike)`; `Array.from(iterable, mapFn)` over
+  `[...iterable].map()`.
+- `Map` when keys aren't strings or are user-provided (prototype pollution); `Set` for dedup; generators for lazy
+  sequences. Never extend built-in prototypes.
+- ES `class` only; `#private` fields; composition over inheritance (`extends` only for true is-a); no empty
+  constructors; `static` for state-free operations. Don't force classes — one method with state is a closure, one
+  method without is a function.
+
+## Docs & JSDoc
+
+- Doc comments (`/** */`) are API documentation — the "no comments" default does not apply. Every exported function,
+  class, and module-level constant gets one; `@param`/`@returns`/`@throws` for non-trivial signatures. Behavior and
+  intent, not implementation. Update the doc in the same edit that changes behavior.
+- Pure-JS (non-TS) code: type via JSDoc with `// @ts-check`; annotate exported boundaries, `@typedef` for shared
+  shapes, skip the obvious.

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -1,0 +1,86 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.mts"
+  - "**/*.cts"
+---
+
+# TypeScript Conventions
+
+Extends [javascript.md](javascript.md). Types encode intent — let the compiler prove the rest. If you need `as` or
+`any`, the types are wrong; fix the types, don't fight the checker.
+
+## Type Safety
+
+- `strict: true` always; also `noUncheckedIndexedAccess` and `noImplicitOverride`.
+- `unknown` over `any`: external values (API responses, `JSON.parse`, user input) and pass-through parameters are
+  `unknown`, narrowed with guards. `any` only for incremental JS migration or test mocks that deliberately bypass
+  checking — with a comment saying why.
+- No non-null assertions (`!`) without a comment explaining why the value cannot be null — prefer narrowing.
+- No `as` on object literals — annotate (`: Foo`); assertions hide missing/extra property errors. `as` is justified
+  only when you genuinely know more than the compiler (DOM APIs returning wide types, trusted external data). Always
+  `as` syntax, never angle brackets. Double assertion goes through `unknown`, never `any`.
+- Never `@ts-ignore` or `@ts-nocheck`. `@ts-expect-error` in tests only, with a comment.
+- `{}` means "any non-nullish value" — almost never what you want. Opaque value: `unknown`; dict-like:
+  `Record<string, unknown>`; any non-primitive: `object`.
+
+## Annotations & Shapes
+
+- Omit trivially inferred types (`const x = 5`). Annotate exported function signatures (params and return) and
+  complex return types where inference goes opaque or wide. Annotate at declaration so errors surface where the bug
+  is, not at distant call sites.
+- `import type` / `export type` for type-only imports and re-exports (`verbatimModuleSyntax`).
+- `interface` for object shapes; `type` for everything else (unions, intersections, tuples, functions,
+  mapped/conditional). Stay consistent within a project.
+- No empty interfaces, no `namespace`, no wrapper types (`String`, `Number`). Data shapes are interfaces, not
+  classes.
+- Nullability: optional `?` over `| undefined`; keep `| null` at the use site (`getUser(): User | null`), not baked
+  into type aliases. `!= null` checks both null and undefined.
+
+## Generics
+
+- Constrain with `extends`, and keep constraints tight. `T` is fine for one parameter; `TKey`/`TValue`/`TItem` for
+  several. Every type parameter must appear in the signature — no unused ones, no return-type-only generics (they
+  can't be inferred).
+- Let inference work: don't pass type arguments the compiler can infer. `NoInfer<T>` when a parameter should be
+  constrained by others rather than drive inference. Defaults: `interface Container<T, U = T[]>`.
+- Built-in utility types over hand-rolled equivalents: `Partial`, `Pick`, `Omit`, `Record`, `Exclude`, `Extract`,
+  `ReturnType`, `Parameters`, `Awaited`. An explicit interface when the type is a distinct domain concept.
+- Complexity budget: unions/interfaces always; utility types for well-known transformations; conditional/mapped/
+  template-literal types for library code only; recursive `infer` chains last resort. If you can't explain a type in
+  one sentence, split or simplify it.
+
+## Narrowing
+
+- Discriminated unions (`kind`/`type` literal field) for variants. Exhaustive switch with
+  `default: { const _exhaustive: never = value; ... }` to catch new variants at compile time.
+- Type predicates (`pet is Fish`) for reusable guards; assertion functions (`asserts value is Error`) for boundary
+  validation. `typeof`/`instanceof`/`in` narrow natively.
+- Pitfalls: `typeof null === "object"` — check null first; truthiness narrowing fails on `""`, `0`, `NaN`, `false` —
+  explicit null checks when those are valid values.
+
+## Enums
+
+- Union of string literals over enum (`type Status = "active" | "inactive"`). If an enum is warranted (runtime
+  object, iteration, namespace for constants), use a string enum; never numeric with implicit values, never mixed
+  members, never coerced to boolean (`level !== Level.NONE`, not `!!level`).
+
+## Functions & Classes
+
+- Union types or optional parameters over overloads; when overloads are unavoidable, specific signatures before
+  general.
+- Callbacks: `void` return when the result is ignored; no optional parameters in callback types — callers may ignore
+  extra args.
+- Classes: omit `public` (default); `readonly` on never-reassigned properties; constructor parameter properties
+  (`constructor(private readonly db: Database)`); initialize fields at declaration; `override` keyword on overrides.
+- Branded types for nominal safety where structural typing is too permissive (domain IDs, validated strings):
+  `type UserId = string & { readonly __brand: unique symbol }` — keep the mechanism consistent project-wide.
+- Array syntax: `T[]` for simple element types, `Array<T>` for complex ones (`Array<string | number>`).
+- Doc comments describe behavior and semantics, not types already visible in the signature.
+
+## tsconfig
+
+- `module: "NodeNext"` when transpiling with tsc; `module: "preserve"` with bundlers (Vite, esbuild);
+  `verbatimModuleSyntax: true` in both. Target `ESNext`; `lib` includes `dom` for browser projects.
+- Keep configs minimal: `extends` for sharing; separate `tsconfig.build.json` excluding tests/scripts.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "enabledPlugins": {
+    "git-commit@foundry": true,
+    "open-source@foundry": true,
+    "skill-enforcer@foundry": true,
+    "the-blueprint@foundry": true,
+    "the-coder@foundry": true,
+    "the-workflow@foundry": true,
+    "javascript@foundry": true,
+    "typescript@foundry": true
+  },
+  "extraKnownMarketplaces": {
+    "foundry": {
+      "source": {
+        "source": "github",
+        "repo": "xobotyi/cc-foundry"
+      }
+    }
+  },
+  "outputStyle": "ai-helpers:Software Engineer"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules
 dist
 coverage
+/.claude/settings.local.json
 
 .pnp.*
 .yarn/*


### PR DESCRIPTION
Adds the Claude Code setup used across ver0 projects, mirroring [react-hookz/web](https://github.com/react-hookz/web).

- `.claude/settings.json` enables the shared foundry plugin set
- `.claude/rules/{javascript,typescript}.md` carry the JS/TS conventions, so agent-side rules match what the linter and formatter enforce
- `.claude/settings.local.json` is gitignored -- machine-local permission and environment overrides

First of a stacked series that migrates the toolchain to Vite+, upgrades dependencies and reworks CI/release.