### PR TITLE
ci: release with a PAT from GH_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,7 @@ jobs:
       github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push')
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
       # required for npm trusted publishing (OIDC)
       id-token: write
     steps:
@@ -33,6 +31,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: 'master'
+          # the job token is read-only; the tag push must use GH_TOKEN from env
+          persist-credentials: false
       - name: 'Setup Vite+'
         uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
@@ -49,5 +49,7 @@ jobs:
 
       - name: 'Release'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # a secret cannot be named GITHUB_*, so the PAT lives in GH_TOKEN --
+          # semantic-release reads either name
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: vp exec semantic-release


### PR DESCRIPTION
### ⚠️ Create the secret before merging

GitHub rejects secret names starting with `GITHUB_`, so the PAT goes in **`GH_TOKEN`**. It needs write on this repo:

- **Classic PAT:** `repo` scope
- **Fine-grained PAT:** repo `ver0-project/deep-equal` -> Contents: write, Issues: write, Pull requests: write

Without it, `semantic-release` fails in `verifyConditions` with *No GitHub token specified*. The Release workflow only runs on `master` pushes, so merging this before the secret exists breaks the next release, not this PR.

### Changes

- `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` -> `GH_TOKEN: ${{ secrets.GH_TOKEN }}`. semantic-release reads either name, so the env var keeps the secret's own name rather than mapping it back to `GITHUB_TOKEN` (which is how [react-hookz/web](https://github.com/react-hookz/web) spells it -- say the word if you want that form for symmetry).
- Job token drops from `contents`/`issues`/`pull-requests: write` to **`contents: read`** -- the PAT carries the write access now. `id-token: write` stays; npm trusted publishing needs it.
- `persist-credentials: false` on checkout. Without it the checkout's `extraheader` auth and the token semantic-release embeds in the push URL both apply to the same remote; with a read-only job token the persisted one cannot push tags anyway.

`actionlint` clean.

### Note on the built-in token

`dependabot-merge` in `ci.yml` still uses `secrets.GITHUB_TOKEN`. That one is the automatic per-job token, not a stored secret, so the naming restriction does not apply and it works as-is. Tell me if you want that switched to the PAT too.